### PR TITLE
Enhanced Player.gd Viewport Rotation

### DIFF
--- a/player_controler/Player.gd
+++ b/player_controler/Player.gd
@@ -4,7 +4,7 @@ extends CharacterBody3D
 @export var min_y : int = -20
 
 @onready var neck = $Neck
-@onready var head = $Neck/Head
+@onready var cam = $Neck/Head/Camera3D
 
 const SPEED = 5.0
 const JUMP_VELOCITY = 4.5
@@ -22,8 +22,8 @@ func _unhandled_input(event):
 	if Input.get_mouse_mode() == Input.MOUSE_MODE_CAPTURED:
 		if event is InputEventMouseMotion:
 			neck.rotate_y(-event.relative.x * 0.01)
-			head.rotate_x(-event.relative.y * 0.01)
-			head.rotation.x = clamp(head.rotation.x, deg_to_rad(-60), deg_to_rad(90))
+			cam.rotate_x(-event.relative.y * 0.01)
+			cam.rotation.x = clamp(cam.rotation.x, deg_to_rad(-60), deg_to_rad(90))
 
 func _physics_process(delta):
 	# Add the gravity.


### PR DESCRIPTION
Me and some friends were continuing to have that FOV issue. I foun that, with the head variable, you're basically rotating the camera from your feet. Doing cam.rotate rather than the head parent object eliminated this. This change also benefits people who don't have this issue because it allows you to place the camera as far up or down the figure as you want, without having to worry about seeing the capsule if you look up too far.